### PR TITLE
keep existing img tag attributes intact

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,8 @@ module.exports = function(html, attachments) {
     attachment.applied = false;
 
     var regexps = [
-      (attachment.fileName) ? new RegExp('<img[^>]*cid:' + attachment.fileName.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&") + '[@"\'][^>]*>', 'ig') : undefined,
-      (attachment.contentId) ? new RegExp('<img[^>]*cid:' + attachment.contentId.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&") + '[@"\'][^>]*>', 'ig') : undefined,
+      (attachment.fileName) ? new RegExp('<img([^>]*)src="cid:' + attachment.fileName.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&") + '[@"\'][^>]*>', 'ig') : undefined,
+      (attachment.contentId) ? new RegExp('<img([^>]*)src="cid:' + attachment.contentId.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&") + '[@"\'][^>]*>', 'ig') : undefined,
     ];
 
     var content = Buffer.isBuffer(attachment.content) ? attachment.content.toString('base64') : attachment.content;
@@ -22,7 +22,7 @@ module.exports = function(html, attachments) {
       if(regexp && regexp.test(html)) {
         attachment.applied = true;
 
-        html = html.replace(regexp, '<img src="data:image/' + extension + ';base64,' + content + '" />');
+        html = html.replace(regexp, '<img$1src="data:image/' + extension + ';base64,' + content + '" />');
       }
     });
   });


### PR DESCRIPTION
When inlining the images in the html, tag attributes like style and height, width are stripped. I altered the regexp to keep them intact.